### PR TITLE
Version 1.1.6

### DIFF
--- a/server.R
+++ b/server.R
@@ -3240,7 +3240,6 @@ shinyServer(
             #   colnames.tmp <- gsub(paste0(g,'$'), g.new, colnames.tmp)
             # }
             colnames(res.comb) <- colnames.tmp
-            View(res.comb)
           }
           
           ## filename 


### PR DESCRIPTION
removed a line of leftover debugging code that would cause an error on RSC